### PR TITLE
feat: incluir novas tabelas no script de reset do banco

### DIFF
--- a/packages/backend/scripts/sql/reset_tables.sql
+++ b/packages/backend/scripts/sql/reset_tables.sql
@@ -8,6 +8,7 @@ USE casamais_db;
 SET FOREIGN_KEY_CHECKS = 0;
 
 -- Drop tabelas com FK primeiro
+DROP TABLE IF EXISTS drogas_utilizadas;
 DROP TABLE IF EXISTS medicamentos_utilizados;
 DROP TABLE IF EXISTS internacoes;
 DROP TABLE IF EXISTS consultas;
@@ -17,6 +18,7 @@ DROP TABLE IF EXISTS despesas;
 DROP TABLE IF EXISTS password_reset_tokens;
 
 -- Drop tabelas base
+DROP TABLE IF EXISTS substancias;
 DROP TABLE IF EXISTS assistidas;
 DROP TABLE IF EXISTS usuarios;
 DROP TABLE IF EXISTS doadores;


### PR DESCRIPTION
## Summary
- Adiciona as tabelas `drogas_utilizadas` e `substancias` ao script de reset do banco de dados
- Atualiza a ordem de drop das tabelas para respeitar as foreign keys

## Test plan
- [x] Verificar que o script SQL executa sem erros
- [x] Confirmar que as novas tabelas são removidas corretamente durante o reset